### PR TITLE
Fix inaccurate thread visuals

### DIFF
--- a/src/public/js/ArchivedMessage/index.js
+++ b/src/public/js/ArchivedMessage/index.js
@@ -45,6 +45,10 @@ class ArchivedMessage {
 
     $messageDetails.find('.deleteArchivedMessage').on('click', this.markMessageDeleted);
     $messageDetails.find('.commentArchivedMessage').on('click', () => {
+      if (store.getCurrentRoom().editor !== store.getCurrentUser().socketId) {
+        return;
+      }
+
       if (store.getCurrentRoom().isCommentingOnId) {
         $messageDetails.find('.commentArchivedMessage').removeClass('clicked');
         store.getCurrentRoom().isCommentingOnId = null;

--- a/src/public/js/EphemeralMessage/sendText.js
+++ b/src/public/js/EphemeralMessage/sendText.js
@@ -9,20 +9,15 @@ export const sendMessage = () => {
     return;
   }
 
-  const currentRoom = store.getCurrentRoom();
-  const currentUser = store.getCurrentUser();
-
-  const {name} = currentUser.getProfile();
-
-  if (currentRoom.constructor.name === 'ArchivalSpace') {
+  if (store.getCurrentRoom().constructor.name === 'ArchivalSpace') {
     fetch('/archive', {
       method: 'POST',
       headers: {'Content-Type': 'application/json'},
       body: JSON.stringify({
-        author: name, 
+        author: store.getCurrentUser().getProfile().name, 
         content,
         room_id: 'archivalSpace',
-        commentable_id: currentRoom.isCommentingOnId,
+        commentable_id: store.getCurrentRoom().isCommentingOnId,
         message_type: 'comment',
       })
     }).catch(e => console.log(e));
@@ -30,12 +25,12 @@ export const sendMessage = () => {
     const gridColumnStart = $('#user .shadow').css('grid-column-start');
     const gridRowStart = $('#user .shadow').css('grid-row-start');
   
-    if ($(`#${currentUser.currentRoomId}-${gridColumnStart}-${gridRowStart}`).length) {
+    if ($(`#${store.getCurrentUser().currentRoomId}-${gridColumnStart}-${gridRowStart}`).length) {
       alert('move to an empty spot to write the msg');
     }
   
     const threadEntryMessageId = $('#writeMessage').attr('data-thread-entry-message');
-    const isPinned = $('#pinMessage').hasClass('clicked') && currentRoom.hasFacilitator(currentUser.socketId);
+    const isPinned = $('#pinMessage').hasClass('clicked') && store.getCurrentRoom().hasFacilitator(store.getCurrentUser().socketId);
     
     const ephemeralMessage = new EphemeralMessage({
       content, 
@@ -46,7 +41,7 @@ export const sendMessage = () => {
       ...store.getCurrentUser().getProfile()
     });
   
-    currentRoom.addEphemeralHistory(ephemeralMessage);
+    store.getCurrentRoom().addEphemeralHistory(ephemeralMessage);
     store.sendToPeers({type: 'text', data: ephemeralMessage.messageData});
     ephemeralMessage.render();
     $('#pinMessage').removeClass('clicked');

--- a/src/public/js/Room/index.js
+++ b/src/public/js/Room/index.js
@@ -202,10 +202,15 @@ export default class Room {
   }
 
   addEphemeralHistory = (textRecord) => {
-    const {id, isPinned} = textRecord.messageData;
+    const {id, isPinned, threadPreviousMessageId} = textRecord.messageData;
     this.ephemeralHistory[id] = textRecord;
     if (isPinned) {
       this.setPinnedMessagesCount();
+    }
+
+    if (threadPreviousMessageId) {
+      const previousMessage = this.ephemeralHistory[threadPreviousMessageId];
+      previousMessage.messageData.threadNextMessageId = id;
     }
     return this.ephemeralHistory[id];
   }

--- a/src/public/js/RoomForm/index.js
+++ b/src/public/js/RoomForm/index.js
@@ -156,7 +156,7 @@ export default class RoomForm {
     } else if (this.options.roomId.length > 25) {
       alert('room names must be max 25 characters');
       isValid = false;
-    } else if (store.getRoom(this.options.roomId.toLowerCase().replaceAll(' ', '-'))) {
+    } else if (Object.keys(store.rooms).map(roomId => roomId.toLowerCase()).includes(this.options.roomId.toLowerCase().replaceAll(' ', '-'))) {
       alert('room names must be unique');
       isValid = false;
     }


### PR DESCRIPTION
This PR fixes inaccurate thread visuals caused by the previous messages in threads not being matched up with the current message in thread through receiving messages through the peer connection. 

Also includes updates to logic getting current rooms, which will attempt to fix inability to leave comments on heroku.